### PR TITLE
Abstract transport and other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+php:
+- "5.3"
+- "5.6"
+install:
+- "composer install"
+script:
+- "vendor/bin/phpunit"

--- a/PayWithAmazon/Client.php
+++ b/PayWithAmazon/Client.php
@@ -276,6 +276,9 @@ class Client implements ClientInterface
 
         $response = $httpCurlRequest->httpGet($url);
         $data 	  = json_decode($response);
+        if (isset($data->error)) {
+            throw new \Exception("{$data->error}: {$data->error_description}");
+        }
 
         if ($data->aud != $this->config['client_id']) {
             // The access token does not belong to us

--- a/PayWithAmazon/Client.php
+++ b/PayWithAmazon/Client.php
@@ -1197,10 +1197,8 @@ class Client implements ClientInterface
 		}
 		
                 $responseObj = $this->getOrderReferenceDetails($setParameters);
-		
 		// Check the Order Reference Status again before making the Authorization.
                 $oroStatus = $responseObj->getOrderReferenceDetailsStatus($responseObj->toXml());
-		
 		if ($oroStatus['State'] === 'Open') {
 		    if ($this->success) {
                     $response = $this->Authorize($authorizeParameters);

--- a/PayWithAmazon/Client.php
+++ b/PayWithAmazon/Client.php
@@ -758,7 +758,7 @@ class Client implements ClientInterface
         $requestParameters    = array_change_key_case($requestParameters, CASE_LOWER);
 
         $fieldMappings = array(
-            'merchant_id' 	=> 'SellerId',
+            'merchant_id' 		=> 'SellerId',
             'amazon_capture_id' => 'AmazonCaptureId',
             'mws_auth_token' 	=> 'MWSAuthToken'
         );
@@ -789,15 +789,15 @@ class Client implements ClientInterface
         $requestParameters    = array_change_key_case($requestParameters, CASE_LOWER);
 
         $fieldMappings = array(
-            'merchant_id' 	  		=> 'SellerId',
-            'amazon_capture_id'   		=> 'AmazonCaptureId',
-            'refund_reference_id' 		=> 'RefundReferenceId',
-            'refund_amount' 	  		=> 'RefundAmount.Amount',
-            'currency_code' 	  		=> 'RefundAmount.CurrencyCode',
-	    'provider_credit_reversal_details'	=> array(),
-            'seller_refund_note'  		=> 'SellerRefundNote',
-            'soft_descriptor' 	  		=> 'SoftDescriptor',
-            'mws_auth_token' 	  		=> 'MWSAuthToken'
+            'merchant_id' 	  					=> 'SellerId',
+            'amazon_capture_id'   				=> 'AmazonCaptureId',
+            'refund_reference_id' 				=> 'RefundReferenceId',
+            'refund_amount' 	  				=> 'RefundAmount.Amount',
+            'currency_code' 	  				=> 'RefundAmount.CurrencyCode',
+			'provider_credit_reversal_details'	=> array(),
+            'seller_refund_note'  				=> 'SellerRefundNote',
+            'soft_descriptor' 	  				=> 'SoftDescriptor',
+            'mws_auth_token' 	  				=> 'MWSAuthToken'
         );
 
         $responseObject = $this->setParametersAndPost($parameters, $fieldMappings, $requestParameters);
@@ -820,7 +820,7 @@ class Client implements ClientInterface
         $requestParameters    = array_change_key_case($requestParameters, CASE_LOWER);
 
         $fieldMappings = array(
-            'merchant_id' 	=> 'SellerId',
+            'merchant_id' 		=> 'SellerId',
             'amazon_refund_id'  => 'AmazonRefundId',
             'mws_auth_token' 	=> 'MWSAuthToken'
         );
@@ -880,19 +880,19 @@ class Client implements ClientInterface
         $requestParameters    = array_change_key_case($requestParameters, CASE_LOWER);
 
         $fieldMappings = array(
-            'merchant_id' 		=> 'SellerId',
-            'id' 			=> 'Id',
-            'id_type' 			=> 'IdType',
+            'merchant_id' 				=> 'SellerId',
+            'id' 						=> 'Id',
+            'id_type' 					=> 'IdType',
             'inherit_shipping_address' 	=> 'InheritShippingAddress',
-            'confirm_now' 		=> 'ConfirmNow',
-            'amount' 			=> 'OrderReferenceAttributes.OrderTotal.Amount',
-            'currency_code' 		=> 'OrderReferenceAttributes.OrderTotal.CurrencyCode',
-            'platform_id' 		=> 'OrderReferenceAttributes.PlatformId',
-            'seller_note' 		=> 'OrderReferenceAttributes.SellerNote',
-            'seller_order_id' 		=> 'OrderReferenceAttributes.SellerOrderAttributes.SellerOrderId',
-            'store_name' 		=> 'OrderReferenceAttributes.SellerOrderAttributes.StoreName',
-            'custom_information' 	=> 'OrderReferenceAttributes.SellerOrderAttributes.CustomInformation',
-            'mws_auth_token' 		=> 'MWSAuthToken'
+            'confirm_now' 				=> 'ConfirmNow',
+            'amount' 					=> 'OrderReferenceAttributes.OrderTotal.Amount',
+            'currency_code' 			=> 'OrderReferenceAttributes.OrderTotal.CurrencyCode',
+            'platform_id' 				=> 'OrderReferenceAttributes.PlatformId',
+            'seller_note' 				=> 'OrderReferenceAttributes.SellerNote',
+            'seller_order_id' 			=> 'OrderReferenceAttributes.SellerOrderAttributes.SellerOrderId',
+            'store_name' 				=> 'OrderReferenceAttributes.SellerOrderAttributes.StoreName',
+            'custom_information' 		=> 'OrderReferenceAttributes.SellerOrderAttributes.CustomInformation',
+            'mws_auth_token' 			=> 'MWSAuthToken'
         );
 
         $responseObject = $this->setParametersAndPost($parameters, $fieldMappings, $requestParameters);
@@ -915,10 +915,10 @@ class Client implements ClientInterface
         $requestParameters    = array_change_key_case($requestParameters, CASE_LOWER);
 
         $fieldMappings = array(
-            'merchant_id' 		  => 'SellerId',
-            'amazon_billing_agreement_id' => 'AmazonBillingAgreementId',
-            'address_consent_token' 	  => 'AddressConsentToken',
-            'mws_auth_token' 		  => 'MWSAuthToken'
+            'merchant_id' 		  			=> 'SellerId',
+            'amazon_billing_agreement_id' 	=> 'AmazonBillingAgreementId',
+            'address_consent_token' 	  	=> 'AddressConsentToken',
+            'mws_auth_token' 		  		=> 'MWSAuthToken'
         );
 
         $responseObject = $this->setParametersAndPost($parameters, $fieldMappings, $requestParameters);
@@ -1464,8 +1464,8 @@ class Client implements ClientInterface
         $statusCode     = 200;
         $this->success = false;
 
-	// Submit the request and read response body
-	try {
+    // Submit the request and read response body
+    try {
             $shouldRetry = true;
             $retries     = 0;
             do {
@@ -1473,26 +1473,24 @@ class Client implements ClientInterface
                     $this->constructUserAgentHeader();
 
                     $httpCurlRequest = new HttpCurl($this->config);
-		    $response = $httpCurlRequest->httpPost($this->mwsServiceUrl, $this->userAgent, $parameters);
-
-		    // Split the API response into Response Body and the other parts of the response into other
-                    list($other, $responseBody) = explode("\r\n\r\n", $response, 2);
-                    $other = preg_split("/\r\n|\n|\r/", $other);
-
-                    list($protocol, $code, $text) = explode(' ', trim(array_shift($other)), 3);
+                    $response = $httpCurlRequest->httpPost($this->mwsServiceUrl, $this->userAgent, $parameters);
+                    $curlResponseInfo = $httpCurlRequest->getCurlResponseInfo();
+                    
+                    $statusCode = $curlResponseInfo["http_code"];
+                    
                     $response = array(
-                        'Status' => (int) $code,
-                        'ResponseBody' => $responseBody
+                        'Status' => $statusCode,
+                        'ResponseBody' => $response
                     );
 
-		    $statusCode = $response['Status'];
-
-		    if ($statusCode == 200) {
+                    $statusCode = $response['Status'];
+                    
+            if ($statusCode == 200) {
                         $shouldRetry    = false;
                         $this->success = true;
                     } elseif ($statusCode == 500 || $statusCode == 503) {
 
-			$shouldRetry = true;
+            $shouldRetry = true;
                         if ($shouldRetry && strtolower($this->config['handle_throttle'])) {
                             $this->pauseOnRetry(++$retries, $statusCode);
                         }

--- a/PayWithAmazon/Client.php
+++ b/PayWithAmazon/Client.php
@@ -226,7 +226,7 @@ class Client implements ClientInterface
         if (array_key_exists(strtolower($name), $this->config)) {
             return $this->config[strtolower($name)];
         } else {
-            throw new \Exception('Key ' . $name . ' is either not a part of the configuration array config or the' . $name . 'does not match the key name in the config array', 1);
+            throw new \Exception('Key ' . $name . ' is either not a part of the configuration array config or does not match the key name in the config array', 1);
         }
     }
 

--- a/PayWithAmazon/HttpCurl.php
+++ b/PayWithAmazon/HttpCurl.php
@@ -12,6 +12,7 @@ class HttpCurl implements HttpCurlInterface
     private $config = array();
     private $header = false;
     private $accessToken = null;
+    private $curlResponseInfo = null;
     
     /* Takes user configuration array as input
      * Takes configuration for API call or IPN config
@@ -84,7 +85,7 @@ class HttpCurl implements HttpCurlInterface
         
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $parameters);
-        curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt($ch, CURLOPT_HEADER, false);
         
         $response = $this->execute($ch);
         return $response;
@@ -115,12 +116,23 @@ class HttpCurl implements HttpCurlInterface
     private function execute($ch)
     {
         $response = '';
+        $response = curl_exec($ch);
         if (!$response = curl_exec($ch)) {
             $error_msg = "Unable to post request, underlying exception of " . curl_error($ch);
             curl_close($ch);
             throw new \Exception($error_msg);
         }
+        else{
+            $this->curlResponseInfo = curl_getinfo($ch);
+        }
         curl_close($ch);
         return $response;
+    }
+    
+    /* Get the output of Curl Getinfo */
+    
+    public function getCurlResponseInfo()
+    {
+        return $this->curlResponseInfo;
     }
 }

--- a/PayWithAmazon/HttpCurl.php
+++ b/PayWithAmazon/HttpCurl.php
@@ -10,31 +10,23 @@ require_once 'Interface.php';
 class HttpCurl implements HttpCurlInterface
 {
     private $config = array();
-    private $header = false;
-    private $accessToken = null;
+    private $headers = null;
     private $curlResponseInfo = null;
-    
+
     /* Takes user configuration array as input
      * Takes configuration for API call or IPN config
      */
-    
+
     public function __construct($config = null)
     {
         $this->config = $config;
     }
-    
+
     /* Setter for boolean header to get the user info */
-    
-    public function setHttpHeader()
+
+    public function setHttpHeaders($headers)
     {
-        $this->header = true;
-    }
-    
-    /* Setter for Access token to get the user info */
-    
-    public function setAccessToken($accesstoken)
-    {
-        $this->accessToken = $accesstoken;
+        $this->headers = $headers;
     }
 
     /* Add the common Curl Parameters to the curl handler $ch
@@ -54,65 +46,62 @@ class HttpCurl implements HttpCurlInterface
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        
+
         if (!is_null($this->config['cabundle_file'])) {
             curl_setopt($ch, CURLOPT_CAINFO, $this->config['cabundle_file']);
         }
-        
+
         if (!empty($userAgent))
             curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
-        
+
         if ($this->config['proxy_host'] != null && $this->config['proxy_port'] != -1) {
             curl_setopt($ch, CURLOPT_PROXY, $this->config['proxy_host'] . ':' . $this->config['proxy_port']);
         }
-        
+
         if ($this->config['proxy_username'] != null && $this->config['proxy_password'] != null) {
             curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->config['proxy_username'] . ':' . $this->config['proxy_password']);
         }
-        
+
+        // Setting the HTTP header with the Access Token only for Getting user info
+        if ($this->headers) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $this->headers);
+        }
+
         return $ch;
     }
-    
+
     /* POST using curl for the following situations
      * 1. API calls
      * 2. IPN certificate retrieval
      * 3. Get User Info
      */
-    
+
     public function httpPost($url, $userAgent = null, $parameters = null)
     {
         $ch = $this->commonCurlParams($url,$userAgent);
-        
+
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $parameters);
         curl_setopt($ch, CURLOPT_HEADER, false);
-        
+
         $response = $this->execute($ch);
         return $response;
     }
-    
+
     /* GET using curl for the following situations
      * 1. IPN certificate retrieval
      * 2. Get User Info
      */
-    
+
     public function httpGet($url, $userAgent = null)
     {
         $ch = $this->commonCurlParams($url,$userAgent);
-        
-        // Setting the HTTP header with the Access Token only for Getting user info
-        if ($this->header) {
-            curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-                'Authorization: bearer ' . $this->accessToken
-            ));
-        }
-        
         $response = $this->execute($ch);
         return $response;
     }
-    
+
     /* Execute Curl request */
-    
+
     private function execute($ch)
     {
         $response = '';

--- a/PayWithAmazon/Interface.php
+++ b/PayWithAmazon/Interface.php
@@ -425,13 +425,10 @@ interface HttpCurlInterface
     
     public function __construct($config = null);
     
-    /* Set Http header for Access token for the GetUserInfo call */
+    /* Set Http header(s) (e.g Access token for the GetUserInfo call) */
     
-    public function setHttpHeader();
+    public function setHttpHeaders($headers);
     
-    /* Setter for  Access token to get the user info */
-    
-    public function setAccessToken($accesstoken);
     
     /* POST using curl for the following situations
      * 1. API calls

--- a/PayWithAmazon/Transport.php
+++ b/PayWithAmazon/Transport.php
@@ -1,0 +1,69 @@
+<?php
+namespace PayWithAmazon;
+
+require_once 'HttpCurl.php';
+
+/**
+ * Used to run real requests.
+ */
+class CurlTransport
+{
+    public function send($params)
+    {
+        $userAgent = isset($params['userAgent']) ? $params['userAgent'] : null;
+        $userAgent = $userAgent ?: null;
+
+        $httpCurlRequest = new HttpCurl($params['config']);
+        if (isset($params['headers'])) {
+            $httpCurlRequest->setHttpHeaders($params['headers']);
+        }
+
+        if ($params['method'] == "POST") {
+            $response = $httpCurlRequest->httpPost($params['url'], $userAgent, $params['parameters']);
+        } else if ($params['method'] == "GET") {
+            $response = $httpCurlRequest->httpGet($params['url'], $userAgent);
+        } else {
+            throw new \InvalidArgumentException("no such method: {$params['method']}");
+        }
+
+        $curlResponseInfo = $httpCurlRequest->getCurlResponseInfo();
+
+        $statusCode = $curlResponseInfo["http_code"];
+
+        return array(
+            'body' => $response,
+            'status' => $statusCode,
+        );
+    }
+}
+
+/**
+ * Used for unit testing.
+ */
+class MockTransport
+{
+    public function __construct()
+    {
+        $this->requests = array();
+        $this->responses = array();
+    }
+
+    public function pushResponse($body, $status=200)
+    {
+        $this->responses[] = array(
+            'body' => $body,
+            'status' => $status,
+        );
+    }
+
+    public function send($params)
+    {
+        $this->requests[] = $params;
+
+        if ($this->responses) {
+            return array_shift($this->responses);
+        } else {
+            throw new \Exception("no responses to respond with");
+        }
+    }
+}

--- a/UnitTests/ClientTest.php
+++ b/UnitTests/ClientTest.php
@@ -1,9 +1,9 @@
 <?php
-namespace PayWithAmazon;
+namespace PayWithAmazon\Tests;
 
-require_once '../PayWithAmazon/Client.php';
-require_once '../PayWithAmazon/ResponseParser.php';
-require_once 'Signature.php';
+use PayWithAmazon\Client;
+use PayWithAmazon\ResponseParser;
+use PayWithAmazon\Tests\Signature;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -16,7 +16,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                 'region' => 'us',
                 'sandbox' => true,
                 'platform_id' => 'test',
-                'cabundle_file' => null,
                 'application_name' => 'sdk testing',
                 'application_version' => '1.0',
                 'proxy_host' => null,
@@ -54,7 +53,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testJsonFile()
     {
         try {
-            $configParams = "config.json";
+            $configParams =  __DIR__ . "/config.json";
             $client = new Client($configParams);
         } catch (\Exception $expected) {
             $this->assertRegExp('/Error with message - content is not in json format./i', strval($expected));

--- a/UnitTests/IpnHandlerTest.php
+++ b/UnitTests/IpnHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace PayWithAmazon;
+namespace PayWithAmazon\Tests;
 
-require_once '../PayWithAmazon/IpnHandler.php';
+use PayWithAmazon\IpnHandler;
 
 class IpnHandlertest extends \PHPUnit_Framework_TestCase
 {

--- a/UnitTests/Signature.php
+++ b/UnitTests/Signature.php
@@ -1,5 +1,5 @@
 <?php
-namespace PayWithAmazon;
+namespace PayWithAmazon\Tests;
 
 class Signature
 {

--- a/UnitTests/bootstrap.php
+++ b/UnitTests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @file
+ * A script containing any set-up steps required for PHPUnit testing.
+ */
+require __DIR__ . '/../vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,16 @@
          "PayWithAmazon\\": "PayWithAmazon/"
       }
    },
+   "autoload-dev": {
+      "psr-4": {
+         "PayWithAmazon\\Tests\\": "UnitTests"
+      }
+   },
    "require": {
       "ext-curl": "*",
       "php": ">=5.3.0"
+   },
+   "require-dev": {
+      "phpunit/phpunit": "4.3.*"
    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,810 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "7b5f706fa71ed0b6ae9394ac851345a2",
+    "content-hash": "4912b9a60300a4d6cbd7cdb327858305",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "^1.3.2",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-10-06 15:47:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "File/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2013-10-10 15:34:57"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2015-06-21 08:01:12"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-09-15 10:49:45"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "2dab9d593997db4abcf58d0daf798eb4e9cecfe1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2dab9d593997db4abcf58d0daf798eb4e9cecfe1",
+                "reference": "2dab9d593997db4abcf58d0daf798eb4e9cecfe1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~2.0",
+                "phpunit/php-file-iterator": "~1.3.2",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "~1.0.2",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.0",
+                "sebastian/diff": "~1.1",
+                "sebastian/environment": "~1.0",
+                "sebastian/exporter": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-11-11 10:11:09"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2015-10-02 06:51:40"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-02-22 15:13:53"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2015-08-03 06:14:51"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2015-06-21 07:55:53"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-06-21 08:04:50"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-06-21 13:59:46"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "eca9019c88fbe250164affd107bc8057771f3f4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/eca9019c88fbe250164affd107bc8057771f3f4d",
+                "reference": "eca9019c88fbe250164affd107bc8057771f3f4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-10-11 09:39:48"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "ext-curl": "*",
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" bootstrap="UnitTests/bootstrap.php">
+    <testsuites>
+        <testsuite name="PayWithAmazon tests">
+            <directory>./UnitTests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./PayWithAmazon/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
I wanted to do some quick patches to solve some usability problems for my integration.  I'm keen to hear your comments on how I can improve this and if you're satisfied with this direction.  I made the PR anyway because I needed some of these features while I'm trying to do the integration but I'm happy to change it up to be more in line with what you're after.

* transport can be switched from curl http to an in-memory list of responses

I needed this to help out with end to end integration testing.  You can fake the entire client object but I never find this quite as good as using the whole protocol and mock objects in php are very awkward.  I also wrap the transport and log the conversation (in the ``send`` method) which is handy for understanding what the library is doing at run time and providing a detailed audit trail.

* error raised when getting an access token fails

Just a minor one, but otherwise you get confusing PHP errors.

* configure travis-ci

I was hoping to get ci working since some tests were failing on master.  It turns out the version of GNUtls there won't allow the usage of SSL there so it was a bit of a bust, but given that the transport can be mocked that can be worked around now.

* merge mglaman's phpunit usage pull request

I found this useful.