### PR TITLE
Added ext-openssl as requirement Cause it needs it for https

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
       }
    },
    "require": {
+      "ext-openssl": "*",
       "ext-curl": "*",
       "php": ">=5.3.0"
    }


### PR DESCRIPTION
This library needs openssl to work and did not have it required in composer.json

HTTPS requests were not working on a server with no php-openssl extention.