### PR TITLE
Update Client.php to replace depracated methods for newer PHP version

### DIFF
--- a/src/OffAmazonPaymentsService/Client.php
+++ b/src/OffAmazonPaymentsService/Client.php
@@ -113,9 +113,19 @@ class OffAmazonPaymentsService_Client implements OffAmazonPaymentsService_Interf
      */
     public function __construct($config = null)
     {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (!defined('PHP_VERSION_ID')) {
+            $version = explode('.', PHP_VERSION);
+            define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
+        }
+        if (PHP_VERSION_ID >= 50600)
+        {
+            ini_set("default_charset", "UTF-8");
+        } else {
+            iconv_set_encoding("internal_encoding", "UTF-8");
+            iconv_set_encoding("input_encoding", "UTF-8");
+            iconv_set_encoding("output_encoding", "UTF-8");
+        }
+
         
         $this->_merchantValues     = OffAmazonPaymentsService_MerchantValuesBuilder::create($config)->build();
         $this->_httpRequestFactory = new HttpRequestFactoryCurlImpl($this->_merchantValues);


### PR DESCRIPTION
using iconv_set_encoding is deprecated in PHP>50600. The proposed change checks the PHP version and uses the new method instead when appropriate.