### PR TITLE
enable user configuration of curl options connecttimeout and timeout

### DIFF
--- a/AmazonPay/Client.php
+++ b/AmazonPay/Client.php
@@ -51,7 +51,9 @@ class Client implements ClientInterface, LoggerAwareInterface
                 'client_id'            => null,
                 'app_id'               => null,
                 'handle_throttle'      => true,
-                'override_service_url' => null
+                'override_service_url' => null,
+                'curl_connecttimeout'  => 300,
+                'curl_timeout'         => 0
             );
 
     private $modePath = null;

--- a/AmazonPay/HttpCurl.php
+++ b/AmazonPay/HttpCurl.php
@@ -56,6 +56,9 @@ class HttpCurl implements HttpCurlInterface
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->config['curl_connecttimeout']);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->config['curl_timeout']);
+
         if (!is_null($this->config['cabundle_file'])) {
             curl_setopt($ch, CURLOPT_CAINFO, $this->config['cabundle_file']);
         }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ composer require amzn/amazon-pay-sdk-php
 | Proxy Password      | `proxy_password`      | Default : `null`			    	   |
 | LWA Client ID       | `client_id`           | Default : `null`			    	   |
 | Handle Throttle     | `handle_throttle`     | Default : `true`<br>Other: `false`	    	   |
+| Curl ConnectTimeout | `curl_connecttimeout` | Default : `300`					  	   |
+| Curl Timeout        | `curl_timeout`        | Default : `0`					    	   |
 
 ## Setting Configuration
 

--- a/tst/unit/ClientTest.php
+++ b/tst/unit/ClientTest.php
@@ -21,7 +21,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                 'proxy_host'           => null,
                 'proxy_port'           => -1,
                 'proxy_username'       => null,
-                'proxy_Password'       => null
+                'proxy_Password'       => null,
+                'curl_connecttimeout'  => 300,
+                'curl_timeout'         => 0
             );
 
     public function testConfigArray()


### PR DESCRIPTION
_Description of changes:_

- enable configuration of CURLOPT_CONNECTTIMEOUT and CURLOPT_TIMEOUT

The values of these new keys are set to the defaults of curl.
Now the user can also change these two values for their requirements.
When server errors occur on amazons side (which can happen, as on dec 7th) you
can now configure to just let the user wait for example 60s before it times out
instead of 300s on each request/process.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
